### PR TITLE
Add compatibility with comment plugins

### DIFF
--- a/ftdetect/tridactyl.vim
+++ b/ftdetect/tridactyl.vim
@@ -3,5 +3,6 @@ augroup VimTridactyl
 augroup END
 
 autocmd VimTridactyl BufNewFile,BufRead *tridactylrc setf tridactyl
+autocmd VimTridactyl FileType tridactyl setlocal commentstring=\"\ %s
 
 " vim: set noet ts=4 sw=4 sts=4:


### PR DESCRIPTION
Like [tcomment_vim](https://github.com/tomtom/tcomment_vim), [vim-commentary](https://github.com/tpope/vim-commentary), [nerdcommenter](https://github.com/preservim/nerdcommenter) or any plugin which use `commentstring`

I hope to be useful